### PR TITLE
Bug http header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ test: uninstall install
 	cd tests && nosetests -v --with-coverage --cover-package=vlab_esrs_api
 
 images: build
-	sudo docker build -f ApiDockerfile -t willnx/vlab-esrs-api .
-	sudo docker build -f WorkerDockerfile -t willnx/vlab-esrs-worker .
+	docker build -f ApiDockerfile -t willnx/vlab-esrs-api .
+	docker build -f WorkerDockerfile -t willnx/vlab-esrs-worker .
 
 up:
 	docker-compose -p vlabesrs up --abort-on-container-exit

--- a/vlab_esrs_api/app.ini
+++ b/vlab_esrs_api/app.ini
@@ -11,3 +11,4 @@ uid = nobody
 gid = nobody
 disable-logging = true
 enabled-threads = True
+buffer-size=32768


### PR DESCRIPTION
Large auth tokens cause uWSGI to reject the HTTP header. Fix is just to increase max HTTP header size uWSGI accepts.